### PR TITLE
Add order management module and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# MiniCoop
+
+Small example project showcasing a very light delivery workflow with Streamlit.
+
+## Running the tests
+
+Install the dependencies (pandas and pytest are required) and execute `pytest`:
+
+```bash
+pip install pandas pytest
+pytest
+```

--- a/admin.py
+++ b/admin.py
@@ -1,20 +1,17 @@
 import streamlit as st
-import pandas as pd
+from orders import load_orders, update_status
 
 st.title("MiniCoop - Interface Admin")
 
-try:
-    commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
-except FileNotFoundError:
+commandes = load_orders()
+if commandes.empty:
     st.warning("Aucune commande pour le moment.")
-    commandes = pd.DataFrame(columns=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
 
 for index, row in commandes.iterrows():
     st.subheader(f"Commande de {row['nom']}")
     st.write(f"Plat : {row['plat']} | Resto : {row['restaurant']} | Heure : {row['heure']}")
     st.write(f"Adresse : {row['adresse']}")
-    coursier = st.text_input(f"Affecter un coursier à cette commande :", key=index)
+    coursier = st.text_input("Affecter un coursier ", key=index)
     if st.button("Affecter", key=f"affecter-{index}"):
-        commandes.at[index, 'coursier'] = coursier
-        commandes.to_csv("data.csv", index=False, header=False)
+        update_status(row['timestamp'], coursier=coursier)
         st.success(f"{coursier} assigné à la commande.")

--- a/client.py
+++ b/client.py
@@ -1,6 +1,6 @@
 import streamlit as st
-import pandas as pd
 from datetime import datetime
+from orders import append_order
 
 st.title("MiniCoop - Passer une commande")
 
@@ -11,14 +11,15 @@ plat = st.text_input("Plat commandé")
 heure = st.time_input("Heure de livraison souhaitée")
 
 if st.button("Envoyer la commande"):
-    nouvelle_commande = pd.DataFrame([{
+    nouvelle_commande = {
         "nom": nom,
         "adresse": adresse,
         "restaurant": restaurant,
         "plat": plat,
         "heure": heure.strftime("%H:%M"),
         "coursier": "",
-        "timestamp": datetime.now().isoformat()
-    }])
-    nouvelle_commande.to_csv("data.csv", mode="a", header=False, index=False)
+        "timestamp": datetime.now().isoformat(),
+        "status": "pending",
+    }
+    append_order(nouvelle_commande)
     st.success("Commande envoyée avec succès !")

--- a/coursier.py
+++ b/coursier.py
@@ -1,18 +1,18 @@
 import streamlit as st
-import pandas as pd
+from orders import load_orders, update_status
 
 st.title("MiniCoop - Interface Coursier")
 
 nom = st.text_input("Ton prénom (coursier)")
 
 if nom:
-    try:
-        commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
-        missions = commandes[commandes["coursier"] == nom]
-        if missions.empty:
-            st.info("Aucune livraison prévue.")
-        else:
-            for _, row in missions.iterrows():
-                st.success(f"{row['plat']} à livrer pour {row['nom']} à {row['adresse']} à {row['heure']}")
-    except FileNotFoundError:
-        st.warning("Aucune commande trouvée.")
+    commandes = load_orders()
+    missions = commandes[commandes["coursier"] == nom]
+    if missions.empty:
+        st.info("Aucune livraison prévue.")
+    else:
+        for index, row in missions.iterrows():
+            st.success(f"{row['plat']} à livrer pour {row['nom']} à {row['adresse']} à {row['heure']}")
+            if st.button("Livrée", key=f"livree-{index}"):
+                update_status(row['timestamp'], status="delivered")
+                st.info("Commande marquée livrée")

--- a/orders.py
+++ b/orders.py
@@ -1,0 +1,35 @@
+from typing import Dict
+import pandas as pd
+
+COLUMNS = [
+    "nom",
+    "adresse",
+    "restaurant",
+    "plat",
+    "heure",
+    "coursier",
+    "timestamp",
+    "status",
+]
+
+def load_orders(path: str = "data.csv") -> pd.DataFrame:
+    """Return the orders dataframe, creating an empty one if needed."""
+    try:
+        df = pd.read_csv(path, names=COLUMNS)
+    except FileNotFoundError:
+        df = pd.DataFrame(columns=COLUMNS)
+    return df
+
+def append_order(order: Dict[str, str], path: str = "data.csv") -> None:
+    """Append a single order to the CSV file."""
+    df = pd.DataFrame([order])
+    df.to_csv(path, mode="a", header=False, index=False)
+
+def update_status(timestamp: str, path: str = "data.csv", **updates: str) -> None:
+    """Update fields for the order matching the timestamp."""
+    df = load_orders(path)
+    mask = df["timestamp"] == timestamp
+    for key, value in updates.items():
+        if key in df.columns:
+            df.loc[mask, key] = value
+    df.to_csv(path, index=False, header=False)

--- a/resto.py
+++ b/resto.py
@@ -1,22 +1,20 @@
 import streamlit as st
-import pandas as pd
+from orders import load_orders, update_status
 
 st.title("MiniCoop - Interface Restaurant")
 
 nom_resto = st.selectbox("Choisissez votre restaurant", ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"])
 
-try:
-    commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
-    commandes_resto = commandes[commandes["restaurant"] == nom_resto]
+commandes = load_orders()
+commandes_resto = commandes[commandes["restaurant"] == nom_resto]
 
-    if commandes_resto.empty:
-        st.info("Aucune commande en attente.")
-    else:
-        for index, row in commandes_resto.iterrows():
-            st.subheader(f"Commande de {row['nom']}")
-            st.write(f"Plat : {row['plat']} | Adresse : {row['adresse']} | Heure : {row['heure']}")
-            st.write(f"Coursier assigné : {row['coursier'] if row['coursier'] else 'Pas encore'}")
-            st.button("Commande prête", key=f"prête-{index}")  # (action pas encore enregistrée)
-
-except FileNotFoundError:
-    st.warning("Aucune commande disponible.")
+if commandes_resto.empty:
+    st.info("Aucune commande en attente.")
+else:
+    for index, row in commandes_resto.iterrows():
+        st.subheader(f"Commande de {row['nom']}")
+        st.write(f"Plat : {row['plat']} | Adresse : {row['adresse']} | Heure : {row['heure']}")
+        st.write(f"Coursier assigné : {row['coursier'] if row['coursier'] else 'Pas encore'}")
+        if st.button("Commande prête", key=f"prete-{index}"):
+            update_status(row['timestamp'], status="ready")
+            st.success("Commande marquée prête")

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from orders import load_orders, append_order, update_status
+
+def test_append_order(tmp_path):
+    csv = tmp_path / "data.csv"
+    order = {
+        "nom": "Alice",
+        "adresse": "1 rue",
+        "restaurant": "Pizza MTP",
+        "plat": "pizza",
+        "heure": "12:00",
+        "coursier": "",
+        "timestamp": datetime.now().isoformat(),
+        "status": "pending",
+    }
+    append_order(order, path=csv)
+    df = load_orders(path=csv)
+    assert len(df) == 1
+    assert df.iloc[0]["nom"] == "Alice"
+
+def test_assign_coursier(tmp_path):
+    csv = tmp_path / "data.csv"
+    ts = datetime.now().isoformat()
+    order = {
+        "nom": "Bob",
+        "adresse": "2 rue",
+        "restaurant": "Tacos Deluxe",
+        "plat": "tacos",
+        "heure": "13:00",
+        "coursier": "",
+        "timestamp": ts,
+        "status": "pending",
+    }
+    append_order(order, path=csv)
+    update_status(ts, path=csv, coursier="John")
+    df = load_orders(path=csv)
+    assert df.iloc[0]["coursier"] == "John"
+
+def test_mark_ready(tmp_path):
+    csv = tmp_path / "data.csv"
+    ts = datetime.now().isoformat()
+    order = {"nom": "Eve", "adresse": "3 rue", "restaurant": "Vegan Bowl", "plat": "bowl", "heure": "14:00", "coursier": "", "timestamp": ts, "status": "pending"}
+    append_order(order, path=csv)
+    update_status(ts, path=csv, status="ready")
+    df = load_orders(path=csv)
+    assert df.iloc[0]["status"] == "ready"
+
+def test_mark_delivered(tmp_path):
+    csv = tmp_path / "data.csv"
+    ts = datetime.now().isoformat()
+    order = {"nom": "Dan", "adresse": "4 rue", "restaurant": "Pizza MTP", "plat": "pizza", "heure": "15:00", "coursier": "Paul", "timestamp": ts, "status": "ready"}
+    append_order(order, path=csv)
+    update_status(ts, path=csv, status="delivered")
+    df = load_orders(path=csv)
+    assert df.iloc[0]["status"] == "delivered"


### PR DESCRIPTION
## Summary
- create `orders.py` helper with basic CSV utilities
- refactor Streamlit apps to use the helper
- add pytest coverage for order updates
- document running tests

## Testing
- `pip install pandas pytest`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844322e93f48320b467cbdd69306359