### PR TITLE
Reformat python files to 79 char limit

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -4,16 +4,43 @@ import pandas as pd
 st.title("MiniCoop - Interface Admin")
 
 try:
-    commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
+    commandes = pd.read_csv(
+        "data.csv",
+        names=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "timestamp",
+        ],
+    )
 except FileNotFoundError:
     st.warning("Aucune commande pour le moment.")
-    commandes = pd.DataFrame(columns=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
+    commandes = pd.DataFrame(
+        columns=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "timestamp",
+        ]
+    )
 
 for index, row in commandes.iterrows():
     st.subheader(f"Commande de {row['nom']}")
-    st.write(f"Plat : {row['plat']} | Resto : {row['restaurant']} | Heure : {row['heure']}")
+    st.write(
+        f"Plat : {row['plat']} | Resto : {row['restaurant']} | "
+        f"Heure : {row['heure']}"
+    )
     st.write(f"Adresse : {row['adresse']}")
-    coursier = st.text_input(f"Affecter un coursier à cette commande :", key=index)
+    coursier = st.text_input(
+        "Affecter un coursier à cette commande :",
+        key=index,
+    )
     if st.button("Affecter", key=f"affecter-{index}"):
         commandes.at[index, 'coursier'] = coursier
         commandes.to_csv("data.csv", index=False, header=False)

--- a/client.py
+++ b/client.py
@@ -6,7 +6,10 @@ st.title("MiniCoop - Passer une commande")
 
 nom = st.text_input("Nom du client")
 adresse = st.text_input("Adresse de livraison")
-restaurant = st.selectbox("Choisissez un restaurant", ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"])
+restaurant = st.selectbox(
+    "Choisissez un restaurant",
+    ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"],
+)
 plat = st.text_input("Plat commandé")
 heure = st.time_input("Heure de livraison souhaitée")
 

--- a/coursier.py
+++ b/coursier.py
@@ -7,12 +7,26 @@ nom = st.text_input("Ton prénom (coursier)")
 
 if nom:
     try:
-        commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
+        commandes = pd.read_csv(
+            "data.csv",
+            names=[
+                "nom",
+                "adresse",
+                "restaurant",
+                "plat",
+                "heure",
+                "coursier",
+                "timestamp",
+            ],
+        )
         missions = commandes[commandes["coursier"] == nom]
         if missions.empty:
             st.info("Aucune livraison prévue.")
         else:
             for _, row in missions.iterrows():
-                st.success(f"{row['plat']} à livrer pour {row['nom']} à {row['adresse']} à {row['heure']}")
+                st.success(
+                    f"{row['plat']} à livrer pour {row['nom']} à "
+                    f"{row['adresse']} à {row['heure']}"
+                )
     except FileNotFoundError:
         st.warning("Aucune commande trouvée.")

--- a/resto.py
+++ b/resto.py
@@ -3,10 +3,24 @@ import pandas as pd
 
 st.title("MiniCoop - Interface Restaurant")
 
-nom_resto = st.selectbox("Choisissez votre restaurant", ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"])
+nom_resto = st.selectbox(
+    "Choisissez votre restaurant",
+    ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"],
+)
 
 try:
-    commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
+    commandes = pd.read_csv(
+        "data.csv",
+        names=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "timestamp",
+        ],
+    )
     commandes_resto = commandes[commandes["restaurant"] == nom_resto]
 
     if commandes_resto.empty:
@@ -14,9 +28,17 @@ try:
     else:
         for index, row in commandes_resto.iterrows():
             st.subheader(f"Commande de {row['nom']}")
-            st.write(f"Plat : {row['plat']} | Adresse : {row['adresse']} | Heure : {row['heure']}")
-            st.write(f"Coursier assigné : {row['coursier'] if row['coursier'] else 'Pas encore'}")
-            st.button("Commande prête", key=f"prête-{index}")  # (action pas encore enregistrée)
+            st.write(
+                f"Plat : {row['plat']} | Adresse : {row['adresse']} | "
+                f"Heure : {row['heure']}"
+            )
+            st.write(
+                f"Coursier assigné : "
+                f"{row['coursier'] if row['coursier'] else 'Pas encore'}"
+            )
+            st.button(
+                "Commande prête", key=f"prête-{index}"
+            )  # (action pas encore enregistrée)
 
 except FileNotFoundError:
     st.warning("Aucune commande disponible.")


### PR DESCRIPTION
## Summary
- wrap long `pd.read_csv` and `selectbox` arguments
- split long f-strings for readability
- ensure no files have lines > 79 characters

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6844322e4d1c8320a009b62e3b263f87