### PR TITLE
Add order status workflow

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -4,17 +4,44 @@ import pandas as pd
 st.title("MiniCoop - Interface Admin")
 
 try:
-    commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
+    commandes = pd.read_csv(
+        "data.csv",
+        names=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "statut",
+            "timestamp",
+        ],
+    )
 except FileNotFoundError:
     st.warning("Aucune commande pour le moment.")
-    commandes = pd.DataFrame(columns=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
+    commandes = pd.DataFrame(
+        columns=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "statut",
+            "timestamp",
+        ]
+    )
 
 for index, row in commandes.iterrows():
     st.subheader(f"Commande de {row['nom']}")
-    st.write(f"Plat : {row['plat']} | Resto : {row['restaurant']} | Heure : {row['heure']}")
+    st.write(
+        f"Plat : {row['plat']} | Resto : {row['restaurant']} | Heure : {row['heure']}"
+    )
     st.write(f"Adresse : {row['adresse']}")
+    st.write(f"Statut actuel : {row['statut']}")
     coursier = st.text_input(f"Affecter un coursier à cette commande :", key=index)
     if st.button("Affecter", key=f"affecter-{index}"):
         commandes.at[index, 'coursier'] = coursier
+        commandes.at[index, 'statut'] = 'affectée'
         commandes.to_csv("data.csv", index=False, header=False)
         st.success(f"{coursier} assigné à la commande.")

--- a/client.py
+++ b/client.py
@@ -11,14 +11,17 @@ plat = st.text_input("Plat commandé")
 heure = st.time_input("Heure de livraison souhaitée")
 
 if st.button("Envoyer la commande"):
-    nouvelle_commande = pd.DataFrame([{
-        "nom": nom,
-        "adresse": adresse,
-        "restaurant": restaurant,
-        "plat": plat,
-        "heure": heure.strftime("%H:%M"),
-        "coursier": "",
-        "timestamp": datetime.now().isoformat()
-    }])
+    nouvelle_commande = pd.DataFrame([
+        {
+            "nom": nom,
+            "adresse": adresse,
+            "restaurant": restaurant,
+            "plat": plat,
+            "heure": heure.strftime("%H:%M"),
+            "coursier": "",
+            "statut": "en_attente",
+            "timestamp": datetime.now().isoformat(),
+        }
+    ])
     nouvelle_commande.to_csv("data.csv", mode="a", header=False, index=False)
     st.success("Commande envoyée avec succès !")

--- a/coursier.py
+++ b/coursier.py
@@ -7,12 +7,31 @@ nom = st.text_input("Ton prénom (coursier)")
 
 if nom:
     try:
-        commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
+        commandes = pd.read_csv(
+            "data.csv",
+            names=[
+                "nom",
+                "adresse",
+                "restaurant",
+                "plat",
+                "heure",
+                "coursier",
+                "statut",
+                "timestamp",
+            ],
+        )
         missions = commandes[commandes["coursier"] == nom]
         if missions.empty:
             st.info("Aucune livraison prévue.")
         else:
-            for _, row in missions.iterrows():
-                st.success(f"{row['plat']} à livrer pour {row['nom']} à {row['adresse']} à {row['heure']}")
+            for index, row in missions.iterrows():
+                st.success(
+                    f"{row['plat']} à livrer pour {row['nom']} à {row['adresse']} à {row['heure']}"
+                )
+                st.write(f"Statut actuel : {row['statut']}")
+                if st.button("Confirmer la livraison", key=f"livree-{index}"):
+                    commandes.at[index, 'statut'] = 'livrée'
+                    commandes.to_csv("data.csv", index=False, header=False)
+                    st.success("Commande livrée !")
     except FileNotFoundError:
         st.warning("Aucune commande trouvée.")

--- a/resto.py
+++ b/resto.py
@@ -6,7 +6,19 @@ st.title("MiniCoop - Interface Restaurant")
 nom_resto = st.selectbox("Choisissez votre restaurant", ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"])
 
 try:
-    commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
+    commandes = pd.read_csv(
+        "data.csv",
+        names=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "statut",
+            "timestamp",
+        ],
+    )
     commandes_resto = commandes[commandes["restaurant"] == nom_resto]
 
     if commandes_resto.empty:
@@ -14,9 +26,17 @@ try:
     else:
         for index, row in commandes_resto.iterrows():
             st.subheader(f"Commande de {row['nom']}")
-            st.write(f"Plat : {row['plat']} | Adresse : {row['adresse']} | Heure : {row['heure']}")
-            st.write(f"Coursier assigné : {row['coursier'] if row['coursier'] else 'Pas encore'}")
-            st.button("Commande prête", key=f"prête-{index}")  # (action pas encore enregistrée)
+            st.write(
+                f"Plat : {row['plat']} | Adresse : {row['adresse']} | Heure : {row['heure']}"
+            )
+            st.write(
+                f"Coursier assigné : {row['coursier'] if row['coursier'] else 'Pas encore'}"
+            )
+            st.write(f"Statut actuel : {row['statut']}")
+            if st.button("Commande prête", key=f"prête-{index}"):
+                commandes.at[index, 'statut'] = 'prête'
+                commandes.to_csv("data.csv", index=False, header=False)
+                st.success("Commande marquée comme prête.")
 
 except FileNotFoundError:
     st.warning("Aucune commande disponible.")


### PR DESCRIPTION
## Summary
- add a `statut` column with default `en_attente` when a client places an order
- display and update status in the admin interface when assigning a courier
- allow restaurants to mark orders as `prête`
- let couriers confirm delivery so orders become `livrée`
- persist all status updates in `data.csv`

## Testing
- `python3 -m py_compile admin.py client.py coursier.py resto.py`

------
https://chatgpt.com/codex/tasks/task_e_6844322b65f08320888ab594f310cad7