### PR TITLE
Refactor CSV order logic with tests

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,20 +1,20 @@
 import streamlit as st
 import pandas as pd
+from orders import load_orders, assign_courier
 
 st.title("MiniCoop - Interface Admin")
 
-try:
-    commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
-except FileNotFoundError:
+commandes = load_orders()
+if commandes.empty:
     st.warning("Aucune commande pour le moment.")
-    commandes = pd.DataFrame(columns=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
 
 for index, row in commandes.iterrows():
     st.subheader(f"Commande de {row['nom']}")
     st.write(f"Plat : {row['plat']} | Resto : {row['restaurant']} | Heure : {row['heure']}")
     st.write(f"Adresse : {row['adresse']}")
-    coursier = st.text_input(f"Affecter un coursier à cette commande :", key=index)
+    coursier = st.text_input(
+        f"Affecter un coursier à cette commande :", key=index
+    )
     if st.button("Affecter", key=f"affecter-{index}"):
-        commandes.at[index, 'coursier'] = coursier
-        commandes.to_csv("data.csv", index=False, header=False)
+        assign_courier(index, coursier)
         st.success(f"{coursier} assigné à la commande.")

--- a/client.py
+++ b/client.py
@@ -1,6 +1,5 @@
 import streamlit as st
-import pandas as pd
-from datetime import datetime
+from orders import append_order
 
 st.title("MiniCoop - Passer une commande")
 
@@ -11,14 +10,11 @@ plat = st.text_input("Plat commandé")
 heure = st.time_input("Heure de livraison souhaitée")
 
 if st.button("Envoyer la commande"):
-    nouvelle_commande = pd.DataFrame([{
-        "nom": nom,
-        "adresse": adresse,
-        "restaurant": restaurant,
-        "plat": plat,
-        "heure": heure.strftime("%H:%M"),
-        "coursier": "",
-        "timestamp": datetime.now().isoformat()
-    }])
-    nouvelle_commande.to_csv("data.csv", mode="a", header=False, index=False)
+    append_order(
+        nom,
+        adresse,
+        restaurant,
+        plat,
+        heure.strftime("%H:%M"),
+    )
     st.success("Commande envoyée avec succès !")

--- a/coursier.py
+++ b/coursier.py
@@ -1,18 +1,16 @@
 import streamlit as st
-import pandas as pd
+from orders import orders_for_courier
 
 st.title("MiniCoop - Interface Coursier")
 
 nom = st.text_input("Ton prénom (coursier)")
 
 if nom:
-    try:
-        commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
-        missions = commandes[commandes["coursier"] == nom]
-        if missions.empty:
-            st.info("Aucune livraison prévue.")
-        else:
-            for _, row in missions.iterrows():
-                st.success(f"{row['plat']} à livrer pour {row['nom']} à {row['adresse']} à {row['heure']}")
-    except FileNotFoundError:
-        st.warning("Aucune commande trouvée.")
+    missions = orders_for_courier(nom)
+    if missions.empty:
+        st.info("Aucune livraison prévue.")
+    else:
+        for _, row in missions.iterrows():
+            st.success(
+                f"{row['plat']} à livrer pour {row['nom']} à {row['adresse']} à {row['heure']}"
+            )

--- a/orders.py
+++ b/orders.py
@@ -1,0 +1,45 @@
+import pandas as pd
+from datetime import datetime
+from pathlib import Path
+
+COLUMNS = ["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"]
+
+
+def load_orders(path: str = "data.csv") -> pd.DataFrame:
+    """Load orders from CSV. Return empty DataFrame if file missing."""
+    file = Path(path)
+    if not file.exists():
+        return pd.DataFrame(columns=COLUMNS)
+    df = pd.read_csv(file, names=COLUMNS, dtype=str)
+    return df.fillna("")
+
+
+def append_order(nom: str, adresse: str, restaurant: str, plat: str, heure: str,
+                 path: str = "data.csv", *, timestamp: str | None = None) -> None:
+    """Append a new order to the CSV."""
+    if timestamp is None:
+        timestamp = datetime.now().isoformat()
+    df = pd.DataFrame([{"nom": nom,
+                        "adresse": adresse,
+                        "restaurant": restaurant,
+                        "plat": plat,
+                        "heure": heure,
+                        "coursier": "",
+                        "timestamp": timestamp}])
+    df.to_csv(path, mode="a", header=False, index=False)
+
+
+def assign_courier(index: int, coursier: str, path: str = "data.csv") -> pd.DataFrame:
+    """Assign a courier to an order and return updated DataFrame."""
+    orders = load_orders(path)
+    if index < 0 or index >= len(orders):
+        raise IndexError("Invalid order index")
+    orders.at[index, "coursier"] = coursier
+    orders.to_csv(path, index=False, header=False)
+    return orders
+
+
+def orders_for_courier(coursier: str, path: str = "data.csv") -> pd.DataFrame:
+    """Return orders assigned to the given courier."""
+    orders = load_orders(path)
+    return orders[orders["coursier"] == coursier]

--- a/resto.py
+++ b/resto.py
@@ -1,22 +1,22 @@
 import streamlit as st
-import pandas as pd
+from orders import load_orders
 
 st.title("MiniCoop - Interface Restaurant")
 
 nom_resto = st.selectbox("Choisissez votre restaurant", ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"])
 
-try:
-    commandes = pd.read_csv("data.csv", names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"])
-    commandes_resto = commandes[commandes["restaurant"] == nom_resto]
+commandes = load_orders()
+commandes_resto = commandes[commandes["restaurant"] == nom_resto]
 
-    if commandes_resto.empty:
-        st.info("Aucune commande en attente.")
-    else:
-        for index, row in commandes_resto.iterrows():
-            st.subheader(f"Commande de {row['nom']}")
-            st.write(f"Plat : {row['plat']} | Adresse : {row['adresse']} | Heure : {row['heure']}")
-            st.write(f"Coursier assigné : {row['coursier'] if row['coursier'] else 'Pas encore'}")
-            st.button("Commande prête", key=f"prête-{index}")  # (action pas encore enregistrée)
-
-except FileNotFoundError:
-    st.warning("Aucune commande disponible.")
+if commandes_resto.empty:
+    st.info("Aucune commande en attente.")
+else:
+    for index, row in commandes_resto.iterrows():
+        st.subheader(f"Commande de {row['nom']}")
+        st.write(
+            f"Plat : {row['plat']} | Adresse : {row['adresse']} | Heure : {row['heure']}"
+        )
+        st.write(
+            f"Coursier assigné : {row['coursier'] if row['coursier'] else 'Pas encore'}"
+        )
+        st.button("Commande prête", key=f"prête-{index}")  # (action pas encore enregistrée)

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from orders import load_orders, append_order, assign_courier, orders_for_courier
+
+
+def test_append_and_load(tmp_path):
+    csv = tmp_path / "data.csv"
+    append_order("Alice", "1 rue A", "Pizza MTP", "Margherita", "12:00", path=csv)
+    df = load_orders(csv)
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert row["nom"] == "Alice"
+    assert row["plat"] == "Margherita"
+    assert row["coursier"] == ""
+
+
+def test_assign_courier(tmp_path):
+    csv = tmp_path / "orders.csv"
+    append_order("Bob", "2 rue B", "Tacos Deluxe", "Burrito", "13:00", path=csv)
+    assign_courier(0, "Charlie", path=csv)
+    df = load_orders(csv)
+    assert df.iloc[0]["coursier"] == "Charlie"
+    missions = orders_for_courier("Charlie", path=csv)
+    assert len(missions) == 1
+    assert missions.iloc[0]["nom"] == "Bob"


### PR DESCRIPTION
## Summary
- centralize CSV order handling into `orders.py`
- refactor UI scripts to use the new helper functions
- add pytest coverage for order creation and courier assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443c9a18708320a622ef532e6d367b