### PR TITLE
Add restaurant menu support

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,13 +1,17 @@
 import streamlit as st
 import pandas as pd
 from datetime import datetime
+import json
+
+with open("menus.json", "r") as f:
+    menus = json.load(f)
 
 st.title("MiniCoop - Passer une commande")
 
 nom = st.text_input("Nom du client")
 adresse = st.text_input("Adresse de livraison")
-restaurant = st.selectbox("Choisissez un restaurant", ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"])
-plat = st.text_input("Plat commandé")
+restaurant = st.selectbox("Choisissez un restaurant", list(menus.keys()))
+plat = st.selectbox("Plat commandé", menus[restaurant])
 heure = st.time_input("Heure de livraison souhaitée")
 
 if st.button("Envoyer la commande"):

--- a/marketplace.py
+++ b/marketplace.py
@@ -1,0 +1,12 @@
+import streamlit as st
+import json
+
+st.title("MiniCoop - Marketplace")
+
+with open("menus.json", "r") as f:
+    menus = json.load(f)
+
+for resto, plats in menus.items():
+    st.header(resto)
+    for plat in plats:
+        st.write(f"- {plat}")

--- a/menus.json
+++ b/menus.json
@@ -1,0 +1,5 @@
+{
+  "Pizza MTP": ["Margherita", "Pepperoni", "Calzone"],
+  "Tacos Deluxe": ["Chicken Taco", "Beef Taco", "Veggie Taco"],
+  "Vegan Bowl": ["Quinoa Salad", "Vegan Burger", "Smoothie"]
+}


### PR DESCRIPTION
## Summary
- maintain per-restaurant menu data in `menus.json`
- allow menu-based dish selection in `client.py`
- add `marketplace.py` to list all restaurants and their menus

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68443c98067c8320991a7f666ab4cf01