### PR TITLE
Fix line length and simplify test imports

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -6,17 +6,36 @@ st.title("MiniCoop - Interface Admin")
 try:
     commandes = pd.read_csv(
         "data.csv",
-        names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"],
+        names=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "timestamp",
+        ],
     )
 except (FileNotFoundError, pd.errors.EmptyDataError):
     st.warning("Aucune commande pour le moment.")
     commandes = pd.DataFrame(
-        columns=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"]
+        columns=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "timestamp",
+        ]
     )
 
 for index, row in commandes.iterrows():
     st.subheader(f"Commande de {row['nom']}")
-    st.write(f"Plat : {row['plat']} | Resto : {row['restaurant']} | Heure : {row['heure']}")
+    st.write(
+        f"Plat : {row['plat']} | Resto : {row['restaurant']} | "
+        f"Heure : {row['heure']}"
+    )
     st.write(f"Adresse : {row['adresse']}")
     coursier = st.text_input(
         "Affecter un coursier à cette commande :",

--- a/coursier.py
+++ b/coursier.py
@@ -9,7 +9,15 @@ if nom:
     try:
         commandes = pd.read_csv(
             "data.csv",
-            names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"],
+            names=[
+                "nom",
+                "adresse",
+                "restaurant",
+                "plat",
+                "heure",
+                "coursier",
+                "timestamp",
+            ],
         )
         missions = commandes[commandes["coursier"] == nom]
         if missions.empty:
@@ -17,10 +25,19 @@ if nom:
         else:
             for _, row in missions.iterrows():
                 st.success(
-                    f"{row['plat']} à livrer pour {row['nom']} à {row['adresse']} à {row['heure']}"
+                    f"{row['plat']} à livrer pour {row['nom']} "
+                    f"à {row['adresse']} à {row['heure']}"
                 )
     except (FileNotFoundError, pd.errors.EmptyDataError):
         st.warning("Aucune commande trouvée.")
         commandes = pd.DataFrame(
-            columns=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"]
+            columns=[
+                "nom",
+                "adresse",
+                "restaurant",
+                "plat",
+                "heure",
+                "coursier",
+                "timestamp",
+            ]
         )

--- a/resto.py
+++ b/resto.py
@@ -3,12 +3,23 @@ import pandas as pd
 
 st.title("MiniCoop - Interface Restaurant")
 
-nom_resto = st.selectbox("Choisissez votre restaurant", ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"])
+nom_resto = st.selectbox(
+    "Choisissez votre restaurant",
+    ["Pizza MTP", "Tacos Deluxe", "Vegan Bowl"],
+)
 
 try:
     commandes = pd.read_csv(
         "data.csv",
-        names=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"],
+        names=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "timestamp",
+        ],
     )
     commandes_resto = commandes[commandes["restaurant"] == nom_resto]
 
@@ -17,12 +28,29 @@ try:
     else:
         for index, row in commandes_resto.iterrows():
             st.subheader(f"Commande de {row['nom']}")
-            st.write(f"Plat : {row['plat']} | Adresse : {row['adresse']} | Heure : {row['heure']}")
-            st.write(f"Coursier assigné : {row['coursier'] if row['coursier'] else 'Pas encore'}")
-            st.button("Commande prête", key=f"prête-{index}")  # (action pas encore enregistrée)
+            st.write(
+                f"Plat : {row['plat']} | Adresse : {row['adresse']} | "
+                f"Heure : {row['heure']}"
+            )
+            st.write(
+                "Coursier assigné : "
+                f"{row['coursier'] if row['coursier'] else 'Pas encore'}"
+            )
+            st.button(
+                "Commande prête",
+                key=f"prête-{index}",
+            )  # (action pas encore enregistrée)
 
 except (FileNotFoundError, pd.errors.EmptyDataError):
     st.warning("Aucune commande disponible.")
     commandes = pd.DataFrame(
-        columns=["nom", "adresse", "restaurant", "plat", "heure", "coursier", "timestamp"]
+        columns=[
+            "nom",
+            "adresse",
+            "restaurant",
+            "plat",
+            "heure",
+            "coursier",
+            "timestamp",
+        ]
     )

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,12 @@
+import importlib
+
+import admin
+import client
+import coursier
+import resto
+import marketplace
+
+
+def test_modules_importable():
+    for module in (admin, client, coursier, resto, marketplace):
+        assert importlib.reload(module) is not None


### PR DESCRIPTION
## Summary
- wrap long lines to satisfy flake8 E501
- add tiny tests and move imports to the top

## Testing
- `flake8 --ignore E203,W503`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844479df6588320ab53942f2b877a2a