### PR TITLE
Add Docker setup and CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Optional React frontend build
+RUN if [ -f ./frontend/package.json ]; then \
+        cd frontend && npm install && npm run build && cd .. ; \
+    fi
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -50,3 +50,15 @@ Run it locally with:
 ```bash
 uvicorn backend.main:app --reload
 ```
+
+## Docker Compose
+
+You can run the API, optional React frontend, and a Postgres database using the
+provided `docker-compose.yml`:
+
+```bash
+docker-compose up --build
+```
+
+The backend will be available on port `8000` and the frontend on `3000` once the
+React app has been built.

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,14 +1,17 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+import os
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./mini_coop.db"
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./mini_coop.db")
 
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    DATABASE_URL,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
+
 
 def init_db():
     Base.metadata.create_all(bind=engine)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: mini_coop
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  api:
+    build: .
+    environment:
+      DATABASE_URL: postgresql://postgres:password@db/mini_coop
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  frontend:
+    image: node:18
+    working_dir: /frontend
+    volumes:
+      - ./frontend:/frontend
+    command: sh -c "npm install && npm run build && npx serve -s build"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api
+
+volumes:
+  db_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fastapi
 uvicorn
 sqlalchemy
 pydantic
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add a Dockerfile for the API (with optional frontend build)
- run the API, Postgres DB, and frontend with docker-compose
- allow configuring the backend DB via `DATABASE_URL`
- add Postgres driver dependency
- document Docker Compose usage
- add GitHub Actions workflow running tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684468dc301c83208293cb1e025563f0