### PR TITLE
Add auth + websocket tests

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,7 +1,8 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+import os
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./mini_coop.db"
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./mini_coop.db")
 
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,25 @@
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import (
+    FastAPI,
+    Depends,
+    HTTPException,
+    Header,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from sqlalchemy.orm import Session
 from datetime import datetime
+import secrets
 
 from . import models, database
 
 app = FastAPI(title="MiniCoop API")
 
 database.init_db()
+
+security = HTTPBasic()
+ACCESS_TOKEN = "secrettoken"
 
 
 def get_db():
@@ -17,8 +30,29 @@ def get_db():
         db.close()
 
 
+def require_token(token: str = Header(None, alias="X-Token")):
+    if token != ACCESS_TOKEN:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+@app.post("/login")
+def login(credentials: HTTPBasicCredentials = Depends(security)):
+    username_match = secrets.compare_digest(credentials.username, "alice")
+    password_match = secrets.compare_digest(credentials.password, "wonderland")
+    if not (username_match and password_match):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+    return {"token": ACCESS_TOKEN}
+
+
 @app.post("/orders", response_model=dict)
-def create_order(order: models.OrderCreate, db: Session = Depends(get_db)):
+def create_order(
+    order: models.OrderCreate,
+    db: Session = Depends(get_db),
+    token: str = Depends(require_token),
+):
     db_order = models.Order(
         nom=order.nom,
         adresse=order.adresse,
@@ -35,7 +69,9 @@ def create_order(order: models.OrderCreate, db: Session = Depends(get_db)):
 
 
 @app.get("/orders", response_model=list[dict])
-def list_orders(db: Session = Depends(get_db)):
+def list_orders(
+    db: Session = Depends(get_db), token: str = Depends(require_token)
+):
     orders = db.query(models.Order).all()
     return [
         {
@@ -53,10 +89,27 @@ def list_orders(db: Session = Depends(get_db)):
 
 
 @app.put("/orders/{order_id}/assign")
-def assign_courier(order_id: int, assignment: models.OrderAssign, db: Session = Depends(get_db)):
+def assign_courier(
+    order_id: int,
+    assignment: models.OrderAssign,
+    db: Session = Depends(get_db),
+    token: str = Depends(require_token),
+):
     order = db.query(models.Order).filter(models.Order.id == order_id).first()
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
     order.coursier = assignment.coursier
     db.commit()
     return {"status": "assigned"}
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            if data == "ping":
+                await websocket.send_text("pong")
+    except WebSocketDisconnect:
+        pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,69 @@
+import os
+from fastapi.testclient import TestClient
+
+# use a temporary database file for tests
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+if os.path.exists("test.db"):
+    os.remove("test.db")
+
+from backend.main import app  # noqa: E402
+from backend.database import init_db  # noqa: E402
+
+client = TestClient(app)
+init_db()
+
+
+def teardown_module(module):
+    if os.path.exists("test.db"):
+        os.remove("test.db")
+
+
+def login_token():
+    response = client.post("/login", auth=("alice", "wonderland"))
+    assert response.status_code == 200
+    return response.json()["token"]
+
+
+def test_create_list_assign():
+    token = login_token()
+    headers = {"X-Token": token}
+    order = {
+        "nom": "John",
+        "adresse": "1 rue A",
+        "restaurant": "Pizza MTP",
+        "plat": "Margherita",
+        "heure": "12:00",
+    }
+    r = client.post("/orders", json=order, headers=headers)
+    assert r.status_code == 200
+    order_id = r.json()["id"]
+
+    r = client.get("/orders", headers=headers)
+    assert r.status_code == 200
+    ids = [o["id"] for o in r.json()]
+    assert order_id in ids
+
+    r = client.put(f"/orders/{order_id}/assign", json={"coursier": "Bob"}, headers=headers)
+    assert r.status_code == 200
+    assert r.json()["status"] == "assigned"
+
+
+def test_authentication_required():
+    order = {
+        "nom": "Jane",
+        "adresse": "2 rue B",
+        "restaurant": "Pizza MTP",
+        "plat": "Veggie",
+        "heure": "13:00",
+    }
+    r = client.post("/orders", json=order)
+    assert r.status_code == 401
+    r = client.get("/orders")
+    assert r.status_code == 401
+
+
+def test_websocket_echo():
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text("ping")
+        data = ws.receive_text()
+        assert data == "pong"


### PR DESCRIPTION
## Summary
- support configurable DB path
- secure order routes with a login endpoint
- implement an example websocket
- test order creation, listing and assignment
- test authentication requirements and websocket handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684468e3e55083209f0cfc7d227a1594